### PR TITLE
fix install path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If the formula conflicts with one from Homebrew/homebrew or another tap, you can
 You can also install via URL:
 
 ```
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-fuse/master/<formula>.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-fuse/master/Formula/<formula>.rb
 ```
 
 ## Acceptable Formulae.


### PR DESCRIPTION
It appears all of the formulas are now in a folder named "Formula" but the README was not updated. This fixed the path in the example command.