### PR TITLE
replace 'fusermount' with 'umount' in encfssh

### DIFF
--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -23,6 +23,7 @@ class Encfs < Formula
 
   def install
     ENV.cxx11
+    inreplace "encfs/encfssh", "fusermount -u", "umount"
     system "make", "-f", "Makefile.dist"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
The encfssh script uses the Linux command 'fusermount -u' to unmount the decrypted directory. Since this command doesn't exist, it fails, leaving your decrypted directory still attached.

This change allows for the directory to be properly unmounted and the removed.
