### PR TITLE
travis.yml: tweak settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,8 @@
-language: objective-c
-matrix:
-  include:
-    - env: OSX=10.11
-      os: osx
-      osx_image: osx10.11
-      rvm: system
-    - env: OSX=10.10
-      os: osx
-      osx_image: xcode7
-      rvm: system
-    - env: OSX=10.9
-      os: osx
-      osx_image: beta-xcode6.2
-      rvm: system
+language: ruby
+os: osx
+env: OSX=10.11
+osx_image: xcode7.3
+rvm: system
 
 before_install:
   - if [ -f ".git/shallow" ]; then travis_retry git fetch --unshallow; fi
@@ -27,7 +17,6 @@ before_install:
   - ln -s $PWD $(brew --repo)/Library/Taps/homebrew/homebrew-fuse
   - cd $(brew --repo)/Library/Taps/homebrew/homebrew-fuse
   - export TRAVIS_BUILD_DIR="$(brew --repo)/Library/Taps/homebrew/homebrew-fuse"
-  - env | grep TRAVIS_
 
 script:
   - brew test-bot --no-bottle


### PR DESCRIPTION
General cleanup and use only one OS X worker (as these workers are shared between the Homebrew organisation).