### PR TITLE
encfs 1.9

### DIFF
--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -1,41 +1,28 @@
 class Encfs < Formula
   desc "Encrypted pass-through FUSE file system"
   homepage "https://vgough.github.io/encfs/"
-  url "https://github.com/vgough/encfs/archive/v1.8.1.tar.gz"
-  sha256 "ed6b69d8aba06382ad01116bbce2e4ad49f8de85cdf4e2fab7ee4ac82af537e9"
-  revision 2
+  url "https://github.com/vgough/encfs/archive/v1.9.tar.gz"
+  sha256 "30d2db1555ec359082046748d278018b8a246dc49c0442291c5671da0486f4bf"
+  head "https://github.com/vgough/encfs.git"
 
-  head do
-    url "https://github.com/vgough/encfs.git"
-    depends_on "cmake" => :build
-  end
-
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
-  depends_on "intltool" => :build
-  depends_on "gettext" => :build
   depends_on "boost"
-  depends_on "rlog"
+  depends_on "gettext"
   depends_on "openssl"
-  depends_on "xz"
   depends_on :osxfuse
 
-  needs :cxx11 if MacOS.version < :mavericks
+  needs :cxx11
 
   def install
-    ENV.cxx11 if MacOS.version < :mavericks
-    if build.head?
-      mkdir "build" do
-        system "cmake", "..", *std_cmake_args
-        system "make", "install"
-      end
-    else
-      system "make", "-f", "Makefile.dist"
-      system "./configure", "--disable-dependency-tracking",
-                            "--prefix=#{prefix}",
-                            "--with-boost=#{HOMEBREW_PREFIX}"
+    ENV.cxx11
+
+    # Undefined symbol "_libintl_gettext"
+    # Reported 11 Sep 2016 https://github.com/vgough/encfs/issues/207
+    ENV.append "LDFLAGS", "-lintl"
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
   end


### PR DESCRIPTION
depend on gettext
add -lintl to LDFLAGS
switch to CMake as had already been done in HEAD
remove rlog dependency, which was dropped upstream a while ago
remove unused xz and intltool dependencies
always require cxx11